### PR TITLE
Fix prepare function pointer types

### DIFF
--- a/capi.mbt
+++ b/capi.mbt
@@ -1240,7 +1240,7 @@ pub extern "C" fn sqlite3_prepare16(
   zSql : AnyType,
   nByte : Int,
   ppStmt : Ref[Sqlite3_stmt],
-  pzTail : Ref[CStr]
+  pzTail : Ref[AnyType]
 ) -> Int = "sqlite3_prepare16"
 
 //int sqlite3_prepare16_v2(sqlite3 * db, const void * zSql, int nByte, sqlite3_stmt ** ppStmt, const void ** pzTail);
@@ -1251,7 +1251,7 @@ pub extern "C" fn sqlite3_prepare16_v2(
   zSql : AnyType,
   nByte : Int,
   ppStmt : Ref[Sqlite3_stmt],
-  pzTail : AnyType
+  pzTail : Ref[AnyType]
 ) -> Int = "sqlite3_prepare16_v2"
 
 //int sqlite3_prepare16_v3(sqlite3 * db, const void * zSql, int nByte, unsigned int prepFlags, sqlite3_stmt ** ppStmt, const void ** pzTail);
@@ -1263,7 +1263,7 @@ pub extern "C" fn sqlite3_prepare16_v3(
   nByte : Int,
   prepFlags : UInt,
   ppStmt : Ref[Sqlite3_stmt],
-  pzTail : AnyType
+  pzTail : Ref[AnyType]
 ) -> Int = "sqlite3_prepare16_v3"
 
 //int sqlite3_prepare_v2(sqlite3 * db, const char * zSql, int nByte, sqlite3_stmt ** ppStmt, const char ** pzTail);
@@ -1274,7 +1274,7 @@ pub extern "C" fn sqlite3_prepare_v2(
   zSql : CStr,
   nByte : Int,
   ppStmt : Ref[Sqlite3_stmt],
-  pzTail : AnyType
+  pzTail : Ref[CStr]
 ) -> Int = "sqlite3_prepare_v2"
 
 //int sqlite3_prepare_v3(sqlite3 * db, const char * zSql, int nByte, unsigned int prepFlags, sqlite3_stmt ** ppStmt, const char ** pzTail);
@@ -1286,7 +1286,7 @@ pub extern "C" fn sqlite3_prepare_v3(
   nByte : Int,
   prepFlags : UInt,
   ppStmt : Ref[Sqlite3_stmt],
-  pzTail : AnyType
+  pzTail : Ref[CStr]
 ) -> Int = "sqlite3_prepare_v3"
 //int sqlite3_release_memory(int);
 

--- a/test/test_sqlite_basic.mbt
+++ b/test/test_sqlite_basic.mbt
@@ -1,22 +1,22 @@
-///| 测试SQLite基础操作
+///| Test basic SQLite operations
 test "SQLite open and close" {
-  // 测试内存数据库连接
+  // test in-memory database connection
   let db = { val: @sqlite3sys.Sqlite3::init() }
   let result = @sqlite3sys.sqlite3_open(
     @sqlite3sys.CStr::from_string(":memory:"),
     db,
   )
 
-  // 检查连接是否成功
+  // verify connection success
   assert_true(result == @sqlite3sys.SQLITE_OK)
   assert_false(@sqlite3sys.Sqlite3::is_nullptr(db.val))
 
-  // 关闭数据库
+  // close database
   let close_result = @sqlite3sys.sqlite3_close(db.val)
   assert_true(close_result == @sqlite3sys.SQLITE_OK)
 }
 
-///| 测试SQL执行
+///| Test SQL execution
 test "simple sql execution" {
   let db = { val: @sqlite3sys.Sqlite3::init() }
   let result = @sqlite3sys.sqlite3_open(
@@ -25,7 +25,7 @@ test "simple sql execution" {
   )
   assert_true(result == @sqlite3sys.SQLITE_OK)
 
-  // 创建表
+  // create table
   let create_sql = @sqlite3sys.CStr::from_string(
     "CREATE TABLE test (id INTEGER PRIMARY KEY, name TEXT)",
   )
@@ -76,7 +76,7 @@ test "prepared statements" {
   )
   |> ignore
 
-  // 准备插入语句
+  // prepare insert statement
   let stmt = { val: @sqlite3sys.Sqlite3_stmt::init() }
   let prepare_sql = @sqlite3sys.CStr::from_string(
     "INSERT INTO users (name, age) VALUES (?, ?)",
@@ -86,7 +86,7 @@ test "prepared statements" {
     prepare_sql,
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
+    @ref.new(@sqlite3sys.CStr::from_string("")),
   )
   assert_true(prepare_result == @sqlite3sys.SQLITE_OK)
   assert_false(@sqlite3sys.Sqlite3_stmt::is_nullptr(stmt.val))
@@ -103,11 +103,11 @@ test "prepared statements" {
   let bind_age = @sqlite3sys.sqlite3_bind_int(stmt.val, 2, 25)
   assert_true(bind_age == @sqlite3sys.SQLITE_OK)
 
-  // 执行语句
+  // execute statement
   let step_result = @sqlite3sys.sqlite3_step(stmt.val)
   assert_true(step_result == @sqlite3sys.SQLITE_DONE)
 
-  // 清理
+  // cleanup
   @sqlite3sys.sqlite3_finalize(stmt.val) |> ignore
   @sqlite3sys.sqlite3_close(db.val) |> ignore
 }
@@ -143,7 +143,7 @@ test "querying data" {
     ),
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
+    @ref.new(@sqlite3sys.CStr::from_string("")),
   )
   |> ignore
   let step_result = @sqlite3sys.sqlite3_step(stmt.val)
@@ -230,7 +230,7 @@ test "handling different data types" {
     @sqlite3sys.CStr::from_string("INSERT INTO types_test VALUES (?, ?, ?, ?)"),
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
+    @ref.new(@sqlite3sys.CStr::from_string("")),
   )
   |> ignore
 
@@ -258,7 +258,7 @@ test "handling different data types" {
     @sqlite3sys.CStr::from_string("SELECT * FROM types_test"),
     -1,
     select_stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
+    @ref.new(@sqlite3sys.CStr::from_string("")),
   )
   |> ignore
   assert_true(

--- a/test/test_sqlite_blob.mbt
+++ b/test/test_sqlite_blob.mbt
@@ -1,27 +1,34 @@
 ///| Test BLOB data handling
 test "BLOB data binding and retrieval" {
   let db = { val: @sqlite3sys.Sqlite3::init() }
-  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db) |> ignore
+  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db)
+  |> ignore
 
   // Create table with BLOB column
   @sqlite3sys.sqlite3_exec(
     db.val,
-    @sqlite3sys.CStr::from_string("CREATE TABLE blob_test (id INTEGER, data BLOB)"),
+    @sqlite3sys.CStr::from_string(
+      "CREATE TABLE blob_test (id INTEGER, data BLOB)",
+    ),
     fn(_data, _cols, _values, _names) { 0 },
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+  )
+  |> ignore
 
   // Test just the basic functions for BLOB
   // We'll use a NULL blob for simplicity
   let stmt = { val: @sqlite3sys.Sqlite3_stmt::init() }
   @sqlite3sys.sqlite3_prepare_v2(
     db.val,
-    @sqlite3sys.CStr::from_string("INSERT INTO blob_test (id, data) VALUES (?, ?)"),
+    @sqlite3sys.CStr::from_string(
+      "INSERT INTO blob_test (id, data) VALUES (?, ?)",
+    ),
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+    @ref.new(@sqlite3sys.CStr::from_string("")),
+  )
+  |> ignore
 
   // Bind values
   @sqlite3sys.sqlite3_bind_int(stmt.val, 1, 1) |> ignore
@@ -38,10 +45,12 @@ test "BLOB data binding and retrieval" {
     @sqlite3sys.CStr::from_string("SELECT id, data FROM blob_test WHERE id = 1"),
     -1,
     select_stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
-
-  assert_true(@sqlite3sys.sqlite3_step(select_stmt.val) == @sqlite3sys.SQLITE_ROW)
+    @ref.new(@sqlite3sys.CStr::from_string("")),
+  )
+  |> ignore
+  assert_true(
+    @sqlite3sys.sqlite3_step(select_stmt.val) == @sqlite3sys.SQLITE_ROW,
+  )
 
   // Check BLOB column functions exist and work
   let blob_bytes = @sqlite3sys.sqlite3_column_bytes(select_stmt.val, 1)
@@ -50,7 +59,6 @@ test "BLOB data binding and retrieval" {
   // Verify column type
   let col_type = @sqlite3sys.sqlite3_column_type(select_stmt.val, 1)
   assert_true(col_type == @sqlite3sys.SQLITE_NULL)
-
   @sqlite3sys.sqlite3_finalize(select_stmt.val) |> ignore
   @sqlite3sys.sqlite3_close(db.val) |> ignore
 }
@@ -58,30 +66,34 @@ test "BLOB data binding and retrieval" {
 ///| Test BLOB with zero length
 test "BLOB zeroblob operations" {
   let db = { val: @sqlite3sys.Sqlite3::init() }
-  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db) |> ignore
-
+  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db)
+  |> ignore
   @sqlite3sys.sqlite3_exec(
     db.val,
-    @sqlite3sys.CStr::from_string("CREATE TABLE zeroblob_test (id INTEGER, data BLOB)"),
+    @sqlite3sys.CStr::from_string(
+      "CREATE TABLE zeroblob_test (id INTEGER, data BLOB)",
+    ),
     fn(_data, _cols, _values, _names) { 0 },
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
-
+  )
+  |> ignore
   let stmt = { val: @sqlite3sys.Sqlite3_stmt::init() }
   @sqlite3sys.sqlite3_prepare_v2(
     db.val,
-    @sqlite3sys.CStr::from_string("INSERT INTO zeroblob_test (id, data) VALUES (?, ?)"),
+    @sqlite3sys.CStr::from_string(
+      "INSERT INTO zeroblob_test (id, data) VALUES (?, ?)",
+    ),
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+    @ref.new(@sqlite3sys.CStr::from_string("")),
+  )
+  |> ignore
 
   // Bind zeroblob
   @sqlite3sys.sqlite3_bind_int(stmt.val, 1, 2) |> ignore
   let zeroblob_result = @sqlite3sys.sqlite3_bind_zeroblob(stmt.val, 2, 100)
   assert_true(zeroblob_result == @sqlite3sys.SQLITE_OK)
-
   assert_true(@sqlite3sys.sqlite3_step(stmt.val) == @sqlite3sys.SQLITE_DONE)
   @sqlite3sys.sqlite3_finalize(stmt.val) |> ignore
 
@@ -92,14 +104,14 @@ test "BLOB zeroblob operations" {
     @sqlite3sys.CStr::from_string("SELECT data FROM zeroblob_test WHERE id = 2"),
     -1,
     select_stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
-
-  assert_true(@sqlite3sys.sqlite3_step(select_stmt.val) == @sqlite3sys.SQLITE_ROW)
-  
+    @ref.new(@sqlite3sys.CStr::from_string("")),
+  )
+  |> ignore
+  assert_true(
+    @sqlite3sys.sqlite3_step(select_stmt.val) == @sqlite3sys.SQLITE_ROW,
+  )
   let blob_size = @sqlite3sys.sqlite3_column_bytes(select_stmt.val, 0)
   assert_true(blob_size == 100)
-
   @sqlite3sys.sqlite3_finalize(select_stmt.val) |> ignore
   @sqlite3sys.sqlite3_close(db.val) |> ignore
 }
@@ -107,24 +119,30 @@ test "BLOB zeroblob operations" {
 ///| Test BLOB operations with sqlite3_blob_* functions
 test "BLOB incremental I/O" {
   let db = { val: @sqlite3sys.Sqlite3::init() }
-  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db) |> ignore
+  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db)
+  |> ignore
 
   // Create table and insert a row with BLOB
   @sqlite3sys.sqlite3_exec(
     db.val,
-    @sqlite3sys.CStr::from_string("CREATE TABLE blob_io_test (id INTEGER PRIMARY KEY, data BLOB)"),
+    @sqlite3sys.CStr::from_string(
+      "CREATE TABLE blob_io_test (id INTEGER PRIMARY KEY, data BLOB)",
+    ),
     fn(_data, _cols, _values, _names) { 0 },
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
-
+  )
+  |> ignore
   @sqlite3sys.sqlite3_exec(
     db.val,
-    @sqlite3sys.CStr::from_string("INSERT INTO blob_io_test (data) VALUES (zeroblob(50))"),
+    @sqlite3sys.CStr::from_string(
+      "INSERT INTO blob_io_test (data) VALUES (zeroblob(50))",
+    ),
     fn(_data, _cols, _values, _names) { 0 },
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+  )
+  |> ignore
 
   // Open BLOB for writing
   let blob_handle = { val: @sqlite3sys.Sqlite3_blob::init() }
@@ -134,8 +152,8 @@ test "BLOB incremental I/O" {
     @sqlite3sys.CStr::from_string("blob_io_test"),
     @sqlite3sys.CStr::from_string("data"),
     1L, // rowid
-    1,  // flags: 1 for write, 0 for read
-    blob_handle
+    1, // flags: 1 for write, 0 for read
+    blob_handle,
   )
   assert_true(open_result == @sqlite3sys.SQLITE_OK)
   assert_false(@sqlite3sys.Sqlite3_blob::is_nullptr(blob_handle.val))
@@ -150,7 +168,7 @@ test "BLOB incremental I/O" {
     blob_handle.val,
     write_data,
     9, // write 9 bytes
-    0  // offset
+    0, // offset
   )
   assert_true(write_result == @sqlite3sys.SQLITE_OK)
 
@@ -166,8 +184,8 @@ test "BLOB incremental I/O" {
     @sqlite3sys.CStr::from_string("blob_io_test"),
     @sqlite3sys.CStr::from_string("data"),
     1L, // rowid
-    0,  // flags: 0 for read
-    read_blob_handle
+    0, // flags: 0 for read
+    read_blob_handle,
   )
   assert_true(read_open_result == @sqlite3sys.SQLITE_OK)
 
@@ -177,7 +195,7 @@ test "BLOB incremental I/O" {
     read_blob_handle.val,
     read_buffer,
     9, // bytes to read
-    0  // offset
+    0, // offset
   )
   assert_true(read_result == @sqlite3sys.SQLITE_OK)
 
@@ -187,4 +205,4 @@ test "BLOB incremental I/O" {
   // Close read handle
   @sqlite3sys.sqlite3_blob_close(read_blob_handle.val) |> ignore
   @sqlite3sys.sqlite3_close(db.val) |> ignore
-} 
+}

--- a/test/test_sqlite_misc.mbt
+++ b/test/test_sqlite_misc.mbt
@@ -1,34 +1,35 @@
 ///| Test miscellaneous SQLite functions
 test "column metadata and names" {
   let db = { val: @sqlite3sys.Sqlite3::init() }
-  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db) |> ignore
-
+  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db)
+  |> ignore
   @sqlite3sys.sqlite3_exec(
     db.val,
-    @sqlite3sys.CStr::from_string("CREATE TABLE meta_test (id INTEGER PRIMARY KEY, name TEXT NOT NULL, age REAL)"),
+    @sqlite3sys.CStr::from_string(
+      "CREATE TABLE meta_test (id INTEGER PRIMARY KEY, name TEXT NOT NULL, age REAL)",
+    ),
     fn(_data, _cols, _values, _names) { 0 },
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
-
+  )
+  |> ignore
   let stmt = { val: @sqlite3sys.Sqlite3_stmt::init() }
   @sqlite3sys.sqlite3_prepare_v2(
     db.val,
     @sqlite3sys.CStr::from_string("SELECT id, name, age FROM meta_test"),
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+    @ref.new(@sqlite3sys.CStr::from_string("")),
+  )
+  |> ignore
 
   // Test column names
   let col0_name = @sqlite3sys.sqlite3_column_name(stmt.val, 0)
   let col0_str = @sqlite3sys.CStr::convert_to_moonbit_string(col0_name)
   assert_true(col0_str == "id")
-
   let col1_name = @sqlite3sys.sqlite3_column_name(stmt.val, 1)
   let col1_str = @sqlite3sys.CStr::convert_to_moonbit_string(col1_name)
   assert_true(col1_str == "name")
-
   let col2_name = @sqlite3sys.sqlite3_column_name(stmt.val, 2)
   let col2_str = @sqlite3sys.CStr::convert_to_moonbit_string(col2_name)
   assert_true(col2_str == "age")
@@ -37,15 +38,12 @@ test "column metadata and names" {
   let col0_decltype = @sqlite3sys.sqlite3_column_decltype(stmt.val, 0)
   let col0_type_str = @sqlite3sys.CStr::convert_to_moonbit_string(col0_decltype)
   assert_true(col0_type_str == "INTEGER")
-
   let col1_decltype = @sqlite3sys.sqlite3_column_decltype(stmt.val, 1)
   let col1_type_str = @sqlite3sys.CStr::convert_to_moonbit_string(col1_decltype)
   assert_true(col1_type_str == "TEXT")
-
   let col2_decltype = @sqlite3sys.sqlite3_column_decltype(stmt.val, 2)
   let col2_type_str = @sqlite3sys.CStr::convert_to_moonbit_string(col2_decltype)
   assert_true(col2_type_str == "REAL")
-
   @sqlite3sys.sqlite3_finalize(stmt.val) |> ignore
   @sqlite3sys.sqlite3_close(db.val) |> ignore
 }
@@ -53,7 +51,8 @@ test "column metadata and names" {
 ///| Test database information functions
 test "database information" {
   let db = { val: @sqlite3sys.Sqlite3::init() }
-  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db) |> ignore
+  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db)
+  |> ignore
 
   // Test threadsafe flag
   let threadsafe = @sqlite3sys.sqlite3_threadsafe()
@@ -67,31 +66,33 @@ test "database information" {
   // Test getting database handle from database (should be same)
   let autocommit = @sqlite3sys.sqlite3_get_autocommit(db.val)
   assert_true(autocommit == 1) // Should be in autocommit mode initially
-
   @sqlite3sys.sqlite3_close(db.val) |> ignore
 }
 
 ///| Test SQL statement utilities
 test "SQL statement utilities" {
   let db = { val: @sqlite3sys.Sqlite3::init() }
-  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db) |> ignore
-
+  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db)
+  |> ignore
   @sqlite3sys.sqlite3_exec(
     db.val,
-    @sqlite3sys.CStr::from_string("CREATE TABLE util_test (id INTEGER, name TEXT)"),
+    @sqlite3sys.CStr::from_string(
+      "CREATE TABLE util_test (id INTEGER, name TEXT)",
+    ),
     fn(_data, _cols, _values, _names) { 0 },
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
-
+  )
+  |> ignore
   let stmt = { val: @sqlite3sys.Sqlite3_stmt::init() }
   @sqlite3sys.sqlite3_prepare_v2(
     db.val,
     @sqlite3sys.CStr::from_string("SELECT * FROM util_test WHERE id = ?"),
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+    @ref.new(@sqlite3sys.CStr::from_string("")),
+  )
+  |> ignore
 
   // Test getting SQL text
   let sql_text = @sqlite3sys.sqlite3_sql(stmt.val)
@@ -102,7 +103,6 @@ test "SQL statement utilities" {
   // Test getting database handle from statement
   let db_handle = @sqlite3sys.sqlite3_db_handle(stmt.val)
   assert_false(@sqlite3sys.Sqlite3::is_nullptr(db_handle))
-
   @sqlite3sys.sqlite3_finalize(stmt.val) |> ignore
   @sqlite3sys.sqlite3_close(db.val) |> ignore
 }
@@ -112,13 +112,12 @@ test "string comparison functions" {
   // Test case-insensitive string comparison
   let result1 = @sqlite3sys.sqlite3_stricmp(
     @sqlite3sys.CStr::from_string("Hello"),
-    @sqlite3sys.CStr::from_string("HELLO")
+    @sqlite3sys.CStr::from_string("HELLO"),
   )
   assert_true(result1 == 0) // Should be equal
-
   let result2 = @sqlite3sys.sqlite3_stricmp(
     @sqlite3sys.CStr::from_string("Hello"),
-    @sqlite3sys.CStr::from_string("World")
+    @sqlite3sys.CStr::from_string("World"),
   )
   assert_false(result2 == 0) // Should not be equal
 
@@ -126,21 +125,20 @@ test "string comparison functions" {
   let result3 = @sqlite3sys.sqlite3_strnicmp(
     @sqlite3sys.CStr::from_string("Hello World"),
     @sqlite3sys.CStr::from_string("HELLO UNIVERSE"),
-    5 // Compare only first 5 characters
+    5, // Compare only first 5 characters
   )
   assert_true(result3 == 0) // First 5 chars should be equal
 
   // Test pattern matching
   let glob_result = @sqlite3sys.sqlite3_strglob(
     @sqlite3sys.CStr::from_string("H*"),
-    @sqlite3sys.CStr::from_string("Hello")
+    @sqlite3sys.CStr::from_string("Hello"),
   )
   assert_true(glob_result == 0) // Should match
-
   let like_result = @sqlite3sys.sqlite3_strlike(
     @sqlite3sys.CStr::from_string("H%"),
     @sqlite3sys.CStr::from_string("Hello"),
-    0U // No escape character
+    0U, // No escape character
   )
   assert_true(like_result == 0) // Should match
-} 
+}

--- a/test/test_sqlite_parameters.mbt
+++ b/test/test_sqlite_parameters.mbt
@@ -1,26 +1,31 @@
 ///| Test parameter binding and statement reuse
 test "parameter count and names" {
   let db = { val: @sqlite3sys.Sqlite3::init() }
-  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db) |> ignore
-
+  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db)
+  |> ignore
   @sqlite3sys.sqlite3_exec(
     db.val,
-    @sqlite3sys.CStr::from_string("CREATE TABLE param_test (id INTEGER, name TEXT, age INTEGER)"),
+    @sqlite3sys.CStr::from_string(
+      "CREATE TABLE param_test (id INTEGER, name TEXT, age INTEGER)",
+    ),
     fn(_data, _cols, _values, _names) { 0 },
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+  )
+  |> ignore
 
   // Prepare statement with named parameters
   let stmt = { val: @sqlite3sys.Sqlite3_stmt::init() }
   @sqlite3sys.sqlite3_prepare_v2(
     db.val,
-    @sqlite3sys.CStr::from_string("INSERT INTO param_test (id, name, age) VALUES (?1, :name, @age)"),
+    @sqlite3sys.CStr::from_string(
+      "INSERT INTO param_test (id, name, age) VALUES (?1, :name, @age)",
+    ),
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
-
+    @ref.new(@sqlite3sys.CStr::from_string("")),
+  )
+  |> ignore
 
   // Check parameter count
   let param_count = @sqlite3sys.sqlite3_bind_parameter_count(stmt.val)
@@ -48,16 +53,14 @@ test "parameter count and names" {
   // Test parameter index lookup
   let name_index = @sqlite3sys.sqlite3_bind_parameter_index(
     stmt.val,
-    @sqlite3sys.CStr::from_string(":name")
+    @sqlite3sys.CStr::from_string(":name"),
   )
   assert_true(name_index == 2)
-
   let age_index = @sqlite3sys.sqlite3_bind_parameter_index(
     stmt.val,
-    @sqlite3sys.CStr::from_string("@age")
+    @sqlite3sys.CStr::from_string("@age"),
   )
   assert_true(age_index == 3)
-
   @sqlite3sys.sqlite3_finalize(stmt.val) |> ignore
   @sqlite3sys.sqlite3_close(db.val) |> ignore
 }
@@ -65,25 +68,31 @@ test "parameter count and names" {
 ///| Test statement reset and reuse
 test "statement reset and clear bindings" {
   let db = { val: @sqlite3sys.Sqlite3::init() }
-  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db) |> ignore
-
+  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db)
+  |> ignore
   @sqlite3sys.sqlite3_exec(
     db.val,
-    @sqlite3sys.CStr::from_string("CREATE TABLE reset_test (id INTEGER, value TEXT)"),
+    @sqlite3sys.CStr::from_string(
+      "CREATE TABLE reset_test (id INTEGER, value TEXT)",
+    ),
     fn(_data, _cols, _values, _names) { 0 },
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+  )
+  |> ignore
 
   // Prepare insert statement
   let stmt = { val: @sqlite3sys.Sqlite3_stmt::init() }
   @sqlite3sys.sqlite3_prepare_v2(
     db.val,
-    @sqlite3sys.CStr::from_string("INSERT INTO reset_test (id, value) VALUES (?, ?)"),
+    @sqlite3sys.CStr::from_string(
+      "INSERT INTO reset_test (id, value) VALUES (?, ?)",
+    ),
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+    @ref.new(@sqlite3sys.CStr::from_string("")),
+  )
+  |> ignore
 
   // First execution
   @sqlite3sys.sqlite3_bind_int(stmt.val, 1, 1) |> ignore
@@ -92,9 +101,9 @@ test "statement reset and clear bindings" {
     2,
     @sqlite3sys.CStr::from_string("first"),
     -1,
-    fn(_ptr) { }
-  ) |> ignore
-
+    fn(_ptr) {  },
+  )
+  |> ignore
   assert_true(@sqlite3sys.sqlite3_step(stmt.val) == @sqlite3sys.SQLITE_DONE)
 
   // Reset the statement for reuse
@@ -108,9 +117,9 @@ test "statement reset and clear bindings" {
     2,
     @sqlite3sys.CStr::from_string("second"),
     -1,
-    fn(_ptr) { }
-  ) |> ignore
-
+    fn(_ptr) {  },
+  )
+  |> ignore
   assert_true(@sqlite3sys.sqlite3_step(stmt.val) == @sqlite3sys.SQLITE_DONE)
 
   // Clear bindings and reset
@@ -120,7 +129,6 @@ test "statement reset and clear bindings" {
 
   // Third execution with NULL values (since bindings are cleared)
   assert_true(@sqlite3sys.sqlite3_step(stmt.val) == @sqlite3sys.SQLITE_DONE)
-
   @sqlite3sys.sqlite3_finalize(stmt.val) |> ignore
 
   // Verify all three records were inserted
@@ -130,13 +138,14 @@ test "statement reset and clear bindings" {
     @sqlite3sys.CStr::from_string("SELECT COUNT(*) FROM reset_test"),
     -1,
     count_stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
-
-  assert_true(@sqlite3sys.sqlite3_step(count_stmt.val) == @sqlite3sys.SQLITE_ROW)
+    @ref.new(@sqlite3sys.CStr::from_string("")),
+  )
+  |> ignore
+  assert_true(
+    @sqlite3sys.sqlite3_step(count_stmt.val) == @sqlite3sys.SQLITE_ROW,
+  )
   let count = @sqlite3sys.sqlite3_column_int(count_stmt.val, 0)
   assert_true(count == 3)
-
   @sqlite3sys.sqlite3_finalize(count_stmt.val) |> ignore
   @sqlite3sys.sqlite3_close(db.val) |> ignore
 }
@@ -144,24 +153,30 @@ test "statement reset and clear bindings" {
 ///| Test multiple rows iteration
 test "multiple rows iteration" {
   let db = { val: @sqlite3sys.Sqlite3::init() }
-  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db) |> ignore
+  @sqlite3sys.sqlite3_open(@sqlite3sys.CStr::from_string(":memory:"), db)
+  |> ignore
 
   // Setup test data
   @sqlite3sys.sqlite3_exec(
     db.val,
-    @sqlite3sys.CStr::from_string("CREATE TABLE iter_test (id INTEGER, name TEXT)"),
+    @sqlite3sys.CStr::from_string(
+      "CREATE TABLE iter_test (id INTEGER, name TEXT)",
+    ),
     fn(_data, _cols, _values, _names) { 0 },
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
-
+  )
+  |> ignore
   @sqlite3sys.sqlite3_exec(
     db.val,
-    @sqlite3sys.CStr::from_string("INSERT INTO iter_test VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')"),
+    @sqlite3sys.CStr::from_string(
+      "INSERT INTO iter_test VALUES (1, 'Alice'), (2, 'Bob'), (3, 'Charlie')",
+    ),
     fn(_data, _cols, _values, _names) { 0 },
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
     @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+  )
+  |> ignore
 
   // Query all rows
   let stmt = { val: @sqlite3sys.Sqlite3_stmt::init() }
@@ -170,8 +185,9 @@ test "multiple rows iteration" {
     @sqlite3sys.CStr::from_string("SELECT id, name FROM iter_test ORDER BY id"),
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
-  ) |> ignore
+    @ref.new(@sqlite3sys.CStr::from_string("")),
+  )
+  |> ignore
 
   // Iterate through rows using a simple while-like approach
   let mut row_count = 0
@@ -207,9 +223,7 @@ test "multiple rows iteration" {
       done = true
     }
   }
-
   assert_true(row_count == 3)
-
   @sqlite3sys.sqlite3_finalize(stmt.val) |> ignore
   @sqlite3sys.sqlite3_close(db.val) |> ignore
-} 
+}

--- a/test/zz_test_sqlite_extended.mbt
+++ b/test/zz_test_sqlite_extended.mbt
@@ -41,7 +41,7 @@ test "statement busy readonly status" {
     @sqlite3sys.CStr::from_string("SELECT 1"),
     -1,
     stmt,
-    @sqlite3sys.Sqlite3::to_void_ptr(@sqlite3sys.Sqlite3::init()),
+    @ref.new(@sqlite3sys.CStr::from_string("")),
   )
   |> ignore
 


### PR DESCRIPTION
## Summary
- correct `sqlite3_prepare_*` pointer parameter types in `capi.mbt`
- adjust tests for new signatures
- translate remaining Chinese comments to English

## Testing
- `moon test --target native`

------
https://chatgpt.com/codex/tasks/task_e_685eaa7c9c2c8331853f5cb3d5c917ee